### PR TITLE
dispatchEvents after block rendering (to fix GTM)

### DIFF
--- a/Controller/Index/Success.php
+++ b/Controller/Index/Success.php
@@ -108,13 +108,13 @@ class Success extends Action
             throw new InvalidOrderId('Invalid order ID');
         }
 
-        // Register this order
-        $this->registerOrder($order);
-
         /** @var Page $resultPage */
         $resultPage = $this->resultPageFactory->create();
         $resultPage->addHandle('checkouttester_index_index');
 
+        // Register this order
+        $this->registerOrder($order);
+        
         return $resultPage;
     }
 


### PR DESCRIPTION
Move dispatchEvents after block rendering, so that GA tag order vars are correctly set
See vendor/magento/module-google-tag-manager/Observer/SetGoogleAnalyticsOnOrderSuccessPageViewObserver.php line 55 for code that fails if blocks are not rendered.