### PR TITLE
Change checkout success class on tester page

### DIFF
--- a/view/frontend/layout/checkouttester_index_index.xml
+++ b/view/frontend/layout/checkouttester_index_index.xml
@@ -15,6 +15,6 @@
         <title>CheckoutTester Success Page</title>
     </head>
     <body>
-        <attribute name="class" value="checkout_onepage_success"/>
+        <attribute name="class" value="checkout-onepage-success"/>
     </body>
 </page>


### PR DESCRIPTION
The body class added by the extension to match the checkout success page is not correct. 
checkout_onepage_success --> checkout-onepage-success
