### PR TITLE
DEL: layout tag in page

### DIFF
--- a/view/frontend/layout/checkouttester_index_index.xml
+++ b/view/frontend/layout/checkouttester_index_index.xml
@@ -9,7 +9,7 @@
  * @license     Open Source License
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="checkout_onepage_success"/>
     <head>
         <title>CheckoutTester Success Page</title>


### PR DESCRIPTION
This allows you to use the layout set in the `checkout_onepage_success.xml`

Having the layout set in the `checkouttester_index_index.xml`.
Makes it a little harder to test different layouts in the checkout success page other than the 1column.

You can work around this.
By also setting the layout for the `checkouttester_index_index.xml` the same as the `checkout_onepage_success.xml`.

Removing the tag altogether.
Will keep the current situation.
But also allows custom checkout success pages.